### PR TITLE
Use global options to pass object names to get from the global env.

### DIFF
--- a/R/start.R
+++ b/R/start.R
@@ -1,6 +1,13 @@
 #' Vizection
 #'
 #' This function launches the Vizection shiny application.
+#' 
+#' By default, Vizection will look for two data frames called \dQuote{genes}
+#' and \dQuote{libs}.  Alternatively, these data frames can be passed as
+#' arguments to the \code{vizection()} function.  Their names will be used to
+#' update the global options (\code{vizection.genes} and \code{vizection.libs})
+#' that Vizection uses to find the objects in the global environment.
+#' 
 #' @param local T if you want host to be "0.0.0.0"
 #' @keywords
 #' @import DT ade4 adegraphics colorspace data.table dendextend dplyr ggplot2
@@ -10,6 +17,9 @@
 #' vizection(genes, libs, F)
 vizection <- function(genes = genes, libs = libs, local = F) {
   
+  options("vizection.genes" = deparse(substitute(genes)))
+  options("vizection.libs"  = deparse(substitute(libs)))
+  
   appDir <- system.file("shiny", "vizection", package = "vizection")
   if (appDir == "") {
     stop("Could not find vizection directory. Try re-installing `vizection`.", call. = FALSE)
@@ -17,4 +27,9 @@ vizection <- function(genes = genes, libs = libs, local = F) {
   
   ifelse(local, runApp(appDir, host="0.0.0.0"), runApp(appDir))
 
+}
+
+.onLoad <- function(libname, pkgname){
+  options("vizection.genes" = "genes")
+  options("vizection.libs"  = "libs")
 }

--- a/inst/shiny/vizection/server.R
+++ b/inst/shiny/vizection/server.R
@@ -13,6 +13,9 @@ library(dendextend)
 library(DT)
 library(plotly)
 
+genes <- get(getOption("vizection.genes"), .GlobalEnv)
+libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+
 # In order to pipe ifelse
 ife <- function(cond, x, y) {
   if(cond) return(x) 

--- a/inst/shiny/vizection/ui.R
+++ b/inst/shiny/vizection/ui.R
@@ -13,6 +13,9 @@ library(dendextend)
 library(DT)
 library(plotly)
 
+genes <- get(getOption("vizection.genes"), .GlobalEnv)
+libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+
 # BEGIN shiny app
 dashboardPage(
   

--- a/man/vizection.Rd
+++ b/man/vizection.Rd
@@ -12,6 +12,13 @@ vizection(genes = genes, libs = libs, local = F)
 \description{
 This function launches the Vizection shiny application.
 }
+\details{
+By default, Vizection will look for two data frames called \dQuote{genes}
+and \dQuote{libs}.  Alternatively, these data frames can be passed as
+arguments to the \code{vizection()} function.  Their names will be used to
+update the global options (\code{vizection.genes} and \code{vizection.libs})
+that Vizection uses to find the objects in the global environment.
+}
 \examples{
 vizection(genes, libs, F)
 }


### PR DESCRIPTION
Before this, `vizection()` would only work with data frames called "genes" and "libs".