### PR TITLE
Support for SummarizedExperiment objects.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     plotly,
     shiny,
     shinydashboard,
-    smallCAGEqc
+    smallCAGEqc,
+    SummarizedExperiment
 License: What license is it under?
 LazyData: true
 RoxygenNote: 6.0.1

--- a/R/start.R
+++ b/R/start.R
@@ -13,11 +13,42 @@
 #'   magrittr shiny shinydashboard smallCAGEqc
 #' @export
 #' @examples
-#' vizection(genes, libs, F)
-vizection <- function(genes = genes, libs = libs, local = F) {
+#' \dontrun{
+#' library("airway")
+#' data("airway")
+#' se <- airway
+#' vizection(se)
+#' 
+#' 
+#' # Older way to run Vizection:
+#' data(iris)
+#' genes <- iris[, 1:4]
+#' libs <- as.data.frame(iris[, "Species"])
+#' colnames(libs) <- c('group')
+#' libs$samplename <- as.character(1:nrow(genes))
+#' rownames(libs) <- libs$samplename 
+#' libs$counts <- rnorm(n = nrow(genes), mean = 1000, sd = 200)
+#' genes <- as.data.frame(t(genes))
+#' vizection(genes = genes, libs = libs, local = FALSE)
+#' }
+
+vizection <- function(se, genes, libs, local = F) {
+
+  if ( !missing(se) & !(missing(genes) & missing(libs)))
+    stop( "Too much input: ", dQuote("SummarizedExperiment"), " objects should be provided "
+        , "without ", dQuote("genes"), " or ", dQuote("libs"), " data.frames.")
+  
+  options("vizection.dataIs" = "se") # Search for SummarizedExperiment by default.
+  
+  if (missing(se) & !missing(genes) & !missing(libs)) {
+    warning( "Using ", dQuote("genes"), " and ", dQuote("libs"), " data.frames "
+           , "is deprecated and will be removed in the future.")
+    options("vizection.dataIs" = "genesAndLibs") # Search for genes and libs data frames.
+  }
   
   options("vizection.genes" = deparse(substitute(genes)))
   options("vizection.libs"  = deparse(substitute(libs)))
+  options("vizection.se"    = deparse(substitute(se)))
   
   appDir <- system.file("shiny", "vizection", package = "vizection")
   if (appDir == "") {
@@ -31,4 +62,5 @@ vizection <- function(genes = genes, libs = libs, local = F) {
 .onLoad <- function(libname, pkgname){
   options("vizection.genes" = "genes")
   options("vizection.libs"  = "libs")
+  options("vizection.se"    = "se")
 }

--- a/README.md
+++ b/README.md
@@ -13,22 +13,15 @@ Load the library:
 
     library(vizection) # Note the lowercase 'v'
     
-If you do not have any dataset you can generate some:
+If you do not have any dataset you can try vizection on some example
+data from Bioconductor, for instance the SummarizedExperiment object
+provided by the [airway](https://bioconductor.org/packages/airway) package.
 
-```
-data(iris)
-genes <- iris[, 1:4]
-libs <- as.data.frame(iris[, "Species"])
-colnames(libs) <- c('group')
-libs$samplename <- as.character(1:nrow(genes))
-rownames(libs) <- libs$samplename 
-libs$counts <- rnorm(n = nrow(genes), mean = 1000, sd = 200)
-genes <- as.data.frame(t(genes))
-
-```
+    data("airway", package = "airway")
+    airway$group <- airway$dex
 
 Start vizection:
 
-    vizection(genes = genes, libs = libs, local = FALSE) # local = TRUE implies host="0.0.0.0" 
+    vizection(airway, local = FALSE) # local = TRUE implies host="0.0.0.0" 
 
 Documentation is under way, some features are still not working properly, please be patient :)

--- a/inst/shiny/vizection/server.R
+++ b/inst/shiny/vizection/server.R
@@ -10,8 +10,21 @@ library(data.table)
 library(DT)
 library(plotly)
 
-genes <- get(getOption("vizection.genes"), .GlobalEnv)
-libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+if (getOption("vizection.dataIs") == "genesAndLibs") {
+  genes <- get(getOption("vizection.genes"), .GlobalEnv)
+  libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+} else if (getOption("vizection.dataIs") == "se") {
+  se    <- get(getOption("vizection.se"),  .GlobalEnv)
+  genes <- SummarizedExperiment::assay(se)   %>% data.frame
+  libs  <- SummarizedExperiment::colData(se) %>% data.frame(stringsAsFactors = FALSE)
+  libs$samplename <- rownames(libs)
+  libs$counts     <- colSums(genes)
+} else stop("Could not detect what data to load.")
+
+if (is.null(libs$group))
+  libs$group <- "No groups"
+
+libs$group %<>% factor
 
 vizectionValidate(genes = genes, libs = libs)
 

--- a/inst/shiny/vizection/ui.R
+++ b/inst/shiny/vizection/ui.R
@@ -12,8 +12,21 @@ library(smallCAGEqc)
 library(dendextend)
 library(DT)
 
-genes <- get(getOption("vizection.genes"), .GlobalEnv)
-libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+if (getOption("vizection.dataIs") == "genesAndLibs") {
+  genes <- get(getOption("vizection.genes"), .GlobalEnv)
+  libs  <- get(getOption("vizection.libs"),  .GlobalEnv)
+} else if (getOption("vizection.dataIs") == "se") {
+  se    <- get(getOption("vizection.se"),  .GlobalEnv)
+  genes <- SummarizedExperiment::assay(se)   %>% data.frame
+  libs  <- SummarizedExperiment::colData(se) %>% data.frame(stringsAsFactors = FALSE)
+  libs$samplename <- rownames(libs)
+  libs$counts     <- colSums(genes)
+} else stop("Could not detect what data to load.")
+
+if (is.null(libs$group))
+  libs$group <- "No groups"
+
+libs$group %<>% factor
 
 # BEGIN shiny app
 dashboardPage(

--- a/man/vizection.Rd
+++ b/man/vizection.Rd
@@ -4,7 +4,7 @@
 \alias{vizection}
 \title{Vizection}
 \usage{
-vizection(genes = genes, libs = libs, local = F)
+vizection(se, genes, libs, local = F)
 }
 \arguments{
 \item{local}{T if you want host to be "0.0.0.0"}
@@ -20,5 +20,22 @@ update the global options (\code{vizection.genes} and \code{vizection.libs})
 that Vizection uses to find the objects in the global environment.
 }
 \examples{
-vizection(genes, libs, F)
+\dontrun{
+library("airway")
+data("airway")
+se <- airway
+vizection(se)
+
+
+# Older way to run Vizection:
+data(iris)
+genes <- iris[, 1:4]
+libs <- as.data.frame(iris[, "Species"])
+colnames(libs) <- c('group')
+libs$samplename <- as.character(1:nrow(genes))
+rownames(libs) <- libs$samplename 
+libs$counts <- rnorm(n = nrow(genes), mean = 1000, sd = 200)
+genes <- as.data.frame(t(genes))
+vizection(genes = genes, libs = libs, local = FALSE)
+}
 }


### PR DESCRIPTION
Bonjour Simon,

these "genes" and "libs" were just a clumsy attempt to reach what the authors of the SummarizedExperiment package did much better.

I think that it would be great for Vizection to at least support SummarizedExperiment objects natively, and perhaps even later drop support for genes/libs table (in favor of explaining how to make a SummarizedExperiment with them).

This pull request lets Vizection load a `SummarizedExperiment`, and then internally turn it into genes/libs tables. Had I more time, I would have liked to make deeper changes where Vizection's functions would use the SE object directly via the `colData` and `assay` functions...

What do you think about it ?